### PR TITLE
fix: missing references in units.yaml and quantities.yaml now completely bidirectional, #90

### DIFF
--- a/quantities.yaml
+++ b/quantities.yaml
@@ -70,6 +70,14 @@ quantities:
     type: nist
   - id: NISTu84
     type: nist
+  - id: NISTu376
+    type: nist
+  - id: NISTu377
+    type: nist
+  - id: NISTu378
+    type: nist
+  - id: NISTu379
+    type: nist
   dimension_reference:
     id: NISTd1
     type: nist
@@ -1426,6 +1434,8 @@ quantities:
   short: specific_volume
   unit_references:
   - id: NISTu101
+    type: nist
+  - id: NISTu1e3/1.u27p10'3
     type: nist
   dimension_reference:
     id: NISTd31

--- a/units.yaml
+++ b/units.yaml
@@ -599,6 +599,8 @@ units:
   quantity_references:
   - id: NISTq24
     type: nist
+  - id: NISTq25
+    type: nist
   - id: NISTq26
     type: nist
   si_derived_bases:
@@ -1656,6 +1658,8 @@ units:
     type: nist
   quantity_references:
   - id: NISTq24
+    type: nist
+  - id: NISTq25
     type: nist
   - id: NISTq26
     type: nist


### PR DESCRIPTION
fix #90

Changes as summarized below.

```
Found 7 bidirectional reference mismatches.

Units that reference quantities without reciprocal references:
+---------------------+--------------------------+-------------+-----------------+
| Unit ID             | Unit Name                | Quantity ID | Quantity Name   |
+---------------------+--------------------------+-------------+-----------------+
| NISTu376            | light week               | NISTq1      | length          |
| NISTu377            | light hour               | NISTq1      | length          |
| NISTu378            | light minute             | NISTq1      | length          |
| NISTu379            | light second             | NISTq1      | length          |
| NISTu1e3/1.u27p10'3 | cubic meter per kilogram | NISTq52     | specific volume |
+---------------------+--------------------------+-------------+-----------------+

Quantities that reference units without reciprocal references:
+-------------+----------------------+---------+-----------+
| Quantity ID | Quantity Name        | Unit ID | Unit Name |
+-------------+----------------------+---------+-----------+
| NISTq25     | potential difference | NISTu16 | volt      |
| NISTq25     | potential difference | NISTu53 | abvolt    |
+-------------+----------------------+---------+-----------+
Added reference to unit NISTu376 (light week) in quantity NISTq1 (length)
Added reference to unit NISTu377 (light hour) in quantity NISTq1 (length)
Added reference to unit NISTu378 (light minute) in quantity NISTq1 (length)
Added reference to unit NISTu379 (light second) in quantity NISTq1 (length)
Added reference to unit NISTu1e3/1.u27p10'3 (cubic meter per kilogram) in quantity NISTq52 (specific volume)
Added reference to quantity NISTq25 (potential difference) in unit NISTu16 (volt)
Added reference to quantity NISTq25 (potential difference) in unit NISTu53 (abvolt)

Changes have been applied. The database is now normalized.

Verifying database consistency...
Verification successful! All references are now bidirectional.

Final Statistics:
Total units: 369
Total quantities: 184
Units with quantity references: 369
Quantities with unit references: 179
Bidirectional mismatches fixed: 7
Remaining mismatches: 0
```