### PR TITLE
fix: differentiate quantities of "neper" and "bel" as independent quantities, fixes #87

### DIFF
--- a/quantities.yaml
+++ b/quantities.yaml
@@ -1162,7 +1162,7 @@ quantities:
   - id: NISTq90
     type: nist
   names:
-  - logarithmic ratio quantities
+  - logarithmic ratio quantities (power-like quantities using decimal logarithms)
   quantity_type: derived
   short: logarithmic_ratio_quantities
   dimension_reference:
@@ -1477,11 +1477,11 @@ quantities:
   - id: NISTq121
     type: nist
   names:
-  - logarithmic decrement
+  - logarithmic decrement (field quantities using natural logarithms)
   quantity_type: derived
   short: logarithmic_decrement
   dimension_reference:
-    id: NISTd80
+    id: NISTd67
     type: nist
 - identifiers:
   - id: NISTq122


### PR DESCRIPTION
fixes #87

## Background

#87 identified that both the "bel" and "neper" units should reference quantities that use the NISTd67 dimension (logarithmic_ratio), but there was an inconsistency in how the quantities were defined.

## Problem Identification

In the unitsdb repository:

1. **NISTq90** (logarithmic_ratio_quantities) correctly used dimension NISTd67 (logarithmic_ratio)
2. **NISTq121** (logarithmic_decrement) incorrectly used dimension NISTd80 (ratio_quantity) instead of NISTd67
3. Both NISTu153 (neper) and NISTu154 (bel) reference NISTq90, but NISTu153 also references NISTq121

This inconsistency meant that:
- The neper unit was referencing both a quantity with the correct dimension (NISTd67) and one with an incorrect dimension (NISTd80)
- The mathematical foundation for both units wasn't consistent, despite both representing logarithmic quantities

## Solution

The solution implemented makes the following changes:

1. **Updated NISTq121 (logarithmic_decrement):**
   - Changed dimension_reference from NISTd80 to NISTd67 (logarithmic_ratio)
   - Updated description to "logarithmic decrement (for field quantities using natural logarithms)"

2. **Updated NISTq90 (logarithmic_ratio_quantities):**
   - Updated description to "logarithmic ratio quantities (for power-like quantities using decimal logarithms)"

## Justification

The changes align with the BIPM documentation (https://www.bipm.org/documents/20126/28426370/working-document-ID-509/f7b8b70c-e48e-fe0b-a7ed-d7acfc722fbf/), which explains:

1. **Two separate logarithmic quantities:**
   - **Logarithmic amplitude ratio:** Used for pure sinusoidal signals, defined using natural logarithm (ln), measured in neper (Np)
   - **Level (or logarithmic ratio):** Used for power-like quantities, defined using decimal logarithm (lg), measured in bel (B)

2. From the document: "It is a rule of the International System that for any given quantity there is only one coherent SI unit. It may seem that in the procedure described in sections 1 and 2 we have defined two different coherent units, the neper and the bel, for the same quantity. Although both quantities are dimensionless, and both are defined as the logarithm of a ratio, the differences described in Sections 1 and 2 support the argument that they are different quantities."

3. From [CCU 15th meeting (2003)](https://www.bipm.org/documents/20126/31581121/15th+meeting/20de29b1-57b5-cdf3-2895-d96910695c42): "After discussion with experts in the field, and with colleagues on the CCU, the President decided to present a modified proposal to the CIPM... recommending that we should recognize two coherent SI units of logarithmic decay for two slightly different quantities: the neper for logarithmic amplitude ratio, and the bel for 'power-like quantities'."
