### PR TITLE
fix: NISTq8 "area" is a derived quantity, just like how NISTq10 "volume" is a derived quantity

### DIFF
--- a/quantities.yaml
+++ b/quantities.yaml
@@ -105,7 +105,7 @@ quantities:
     type: nist
   names:
   - area
-  quantity_type: base
+  quantity_type: derived
   short: area
   dimension_reference:
     id: NISTd8


### PR DESCRIPTION
fix: NISTq8 "area" is a derived quantity, just like how NISTq10 "volume" is a derived quantity

fix #58