### PR TITLE
feat: add relative_humidity (unit + quantity) and decibel_milliwatt (unit)

### DIFF
--- a/quantities.yaml
+++ b/quantities.yaml
@@ -2279,3 +2279,13 @@ quantities:
   dimension_reference:
     id: NISTd99
     type: nist
+- identifiers:
+  - id: NISTq199
+    type: nist
+  names:
+  - relative humidity
+  quantity_type: derived
+  short: relative_humidity
+  dimension_reference:
+    id: NISTd80
+    type: nist

--- a/units.yaml
+++ b/units.yaml
@@ -8060,6 +8060,33 @@ units:
   - id: non-SI_acceptable
     type: nist
 - identifiers:
+  - id: NISTu381
+    type: nist
+  quantity_references:
+  - id: NISTq90
+    type: nist
+  names:
+  - dBm
+  - decibel-milliwatt
+  root: true
+  short: decibel_milliwatt
+  symbols:
+  - latex: '\ensuremath{\mathrm{dBm}}'
+    unicode: dBm
+    ascii: dBm
+    html: dBm
+    id: dBm
+    mathml: "<mi mathvariant='normal'>dBm</mi>"
+  - latex: "\\ensuremath{\\mathrm{dB_{mW}}}"
+    unicode: dB_mW
+    ascii: dB_mW
+    html: dB<sub>mW</sub>
+    id: dB_mW
+    mathml: "<msub><mrow><mi mathvariant='normal'>dB</mi></mrow><mrow><mi mathvariant='normal'>mW</mi></mrow></msub>"
+  unit_system_reference:
+  - id: non-SI_not_acceptable
+    type: nist
+- identifiers:
   - id: NISTu400
     type: nist
   quantity_references:

--- a/units.yaml
+++ b/units.yaml
@@ -8087,6 +8087,33 @@ units:
   - id: non-SI_not_acceptable
     type: nist
 - identifiers:
+  - id: NISTu382
+    type: nist
+  quantity_references:
+  - id: NISTq199
+    type: nist
+  names:
+  - relative humidity
+  - percent relative humidity
+  root: true
+  short: relative_humidity
+  symbols:
+  - latex: '\ensuremath{\mathrm{RH}}'
+    unicode: 'RH'
+    ascii: 'RH'
+    html: 'RH'
+    id: rh
+    mathml: "<mi mathvariant='normal'>RH</mi>"
+  - latex: '\ensuremath{\mathrm{\%rh}}'
+    unicode: '%rh'
+    ascii: '%rh'
+    html: '%rh'
+    id: rh_percent
+    mathml: "<mi mathvariant='normal'>%rh</mi>"
+  unit_system_reference:
+  - id: non-SI_not_acceptable
+    type: nist
+- identifiers:
   - id: NISTu400
     type: nist
   quantity_references:


### PR DESCRIPTION
fixes #48

This PR addresses GitHub issue #48 to add `dBm` (decibels relative to a milliwatt) and `%rh` (relative humidity) units to the database, which are used in JSA-S1022:2024.

## Changes

### 1. Adding a New Quantity

Added a new quantity for 'relative humidity':
- ID: `NISTq199`
- Type: derived
- Short: relative_humidity
- Dimension: Dimensionless (NISTd80 - ratio_quantity dimension)

### 2. Adding New Units

#### 2.1. dBm (decibels relative to a milliwatt)
- ID: `NISTu381`
- Quantity reference: NISTq90 (logarithmic ratio quantities)
- Names: "dBm", "decibel-milliwatt"
- Symbols: dBm
- Unit system: non-SI_not_acceptable

#### 2.2. %rh (percent relative humidity)
- ID: `NISTu382`
- Quantity reference: NISTq199 (relative humidity quantity)
- Names: "relative humidity", "percent relative humidity"
- Symbols: "RH", "%rh"
- Unit system: non-SI_not_acceptable
