### PR TITLE
Add requested ISO and IEC 80000 units

### DIFF
--- a/dimensions.yaml
+++ b/dimensions.yaml
@@ -1209,3 +1209,26 @@ dimensions:
   short: fuel_efficiency
   names:
   - fuel efficiency
+- identifiers:
+  - id: NISTd100
+    type: nist
+  dimensionless: true
+  short: traffic_intensity
+  names:
+  - traffic intensity
+- identifiers:
+  - id: NISTd101
+    type: nist
+  short: symbol_rate
+  names:
+  - symbol rate
+  time:
+    power: -1
+    symbol: T
+- identifiers:
+  - id: NISTd102
+    type: nist
+  dimensionless: true
+  short: information_content
+  names:
+  - information content

--- a/quantities.yaml
+++ b/quantities.yaml
@@ -2299,3 +2299,34 @@ quantities:
   dimension_reference:
     id: NISTd67
     type: nist
+- identifiers:
+  - id: NISTq201
+    type: nist
+  names:
+  - traffic intensity
+  quantity_type: derived
+  short: traffic_intensity
+  dimension_reference:
+    id: NISTd100
+    type: nist
+- identifiers:
+  - id: NISTq202
+    type: nist
+  names:
+  - symbol rate
+  quantity_type: derived
+  short: symbol_rate
+  dimension_reference:
+    id: NISTd101
+    type: nist
+- identifiers:
+  - id: NISTq203
+    type: nist
+  names:
+  - information content
+  - information entropy
+  quantity_type: derived
+  short: information_content
+  dimension_reference:
+    id: NISTd102
+    type: nist

--- a/quantities.yaml
+++ b/quantities.yaml
@@ -2289,3 +2289,13 @@ quantities:
   dimension_reference:
     id: NISTd80
     type: nist
+- identifiers:
+  - id: NISTq200
+    type: nist
+  names:
+  - logarithmic frequency range
+  quantity_type: derived
+  short: logarithmic_frequency_range
+  dimension_reference:
+    id: NISTd67
+    type: nist

--- a/units.yaml
+++ b/units.yaml
@@ -8114,6 +8114,46 @@ units:
   - id: non-SI_not_acceptable
     type: nist
 - identifiers:
+  - id: NISTu383
+    type: nist
+  quantity_references:
+  - id: NISTq200
+    type: nist
+  names:
+  - octave
+  root: true
+  short: octave
+  symbols:
+  - latex: "\\ensuremath{\\mathrm{oct}}"
+    unicode: oct
+    ascii: oct
+    html: oct
+    id: oct
+    mathml: "<mi mathvariant='normal'>oct</mi>"
+  unit_system_reference:
+  - id: non-SI_not_acceptable
+    type: nist
+- identifiers:
+  - id: NISTu384
+    type: nist
+  quantity_references:
+  - id: NISTq200
+    type: nist
+  names:
+  - decade
+  root: true
+  short: decade
+  symbols:
+  - latex: "\\ensuremath{\\mathrm{dec}}"
+    unicode: dec
+    ascii: dec
+    html: dec
+    id: dec
+    mathml: "<mi mathvariant='normal'>dec</mi>"
+  unit_system_reference:
+  - id: non-SI_not_acceptable
+    type: nist
+- identifiers:
   - id: NISTu400
     type: nist
   quantity_references:

--- a/units.yaml
+++ b/units.yaml
@@ -8154,6 +8154,86 @@ units:
   - id: non-SI_not_acceptable
     type: nist
 - identifiers:
+  - id: NISTu385
+    type: nist
+  quantity_references:
+  - id: NISTq201
+    type: nist
+  names:
+  - erlang
+  root: true
+  short: erlang
+  symbols:
+  - latex: "\\ensuremath{\\mathrm{E}}"
+    unicode: E
+    ascii: E
+    html: E
+    id: E_erlang
+    mathml: "<mi mathvariant='normal'>E</mi>"
+  unit_system_reference:
+  - id: non-SI_not_acceptable
+    type: nist
+- identifiers:
+  - id: NISTu386
+    type: nist
+  quantity_references:
+  - id: NISTq202
+    type: nist
+  names:
+  - baud
+  root: true
+  short: baud
+  symbols:
+  - latex: "\\ensuremath{\\mathrm{Bd}}"
+    unicode: Bd
+    ascii: Bd
+    html: Bd
+    id: Bd
+    mathml: "<mi mathvariant='normal'>Bd</mi>"
+  unit_system_reference:
+  - id: non-SI_not_acceptable
+    type: nist
+- identifiers:
+  - id: NISTu387
+    type: nist
+  quantity_references:
+  - id: NISTq203
+    type: nist
+  names:
+  - shannon
+  root: true
+  short: shannon
+  symbols:
+  - latex: "\\ensuremath{\\mathrm{Sh}}"
+    unicode: Sh
+    ascii: Sh
+    html: Sh
+    id: Sh
+    mathml: "<mi mathvariant='normal'>Sh</mi>"
+  unit_system_reference:
+  - id: non-SI_not_acceptable
+    type: nist
+- identifiers:
+  - id: NISTu388
+    type: nist
+  quantity_references:
+  - id: NISTq203
+    type: nist
+  names:
+  - hartley
+  root: true
+  short: hartley
+  symbols:
+  - latex: "\\ensuremath{\\mathrm{Hart}}"
+    unicode: Hart
+    ascii: Hart
+    html: Hart
+    id: Hart
+    mathml: "<mi mathvariant='normal'>Hart</mi>"
+  unit_system_reference:
+  - id: non-SI_not_acceptable
+    type: nist
+- identifiers:
   - id: NISTu400
     type: nist
   quantity_references:


### PR DESCRIPTION
### Issue #37: ISO 80000-8: Add Octave and Decade units for logarithmic frequency range quantity
- Added units for logarithmic frequency range (octave and decade)
- Added quantity definition from ISO 80000-8:
  - G = "lb"(f₂/f₁) "oct" = "lg" (f₂/f₁) "dec"
  - One octave represents a frequency ratio where f₂/f₁ = 2
  - One decade represents a frequency ratio where f₂/f₁ = 10
  - 1 "dec" = ("lb" 10) "oct" ≈ 3.322 "oct"

### Issue #40: IEC 80000-13: Add Erlang (E), Baud (Bd), Shannon (Sh), Hartley (Hart)
- Added telecommunications and information theory units
- Erlang (E): Unit for traffic intensity in telecommunications systems
- Baud (Bd): Unit for symbol rate in digital communications
- Shannon (Sh): Unit for information content/entropy using base-2 logarithm
- Hartley (Hart): Unit for information content using base-10 logarithm

## New Dimensions Added

| ID | Name | Description | Dimensionless |
|----|------|-------------|--------------|
| NISTd100 | traffic_intensity | Traffic intensity dimension | Yes |
| NISTd101 | symbol_rate | Symbol rate dimension (T⁻¹) | No |
| NISTd102 | information_content | Information content/entropy dimension | Yes |

## New Quantities Added

| ID | Name | Short Name | Type | Dimension |
|----|------|------------|------|-----------|
| NISTq200 | logarithmic frequency range | logarithmic_frequency_range | derived | NISTd67 (logarithmic_ratio) |
| NISTq201 | traffic intensity | traffic_intensity | derived | NISTd102 |
| NISTq202 | symbol rate | symbol_rate | derived | NISTd101 |
| NISTq203 | information content/entropy | information_content | derived | NISTd100 |

## New Units Added

| ID | Unit | Symbol | Quantity | Description |
|----|------|--------|----------|-------------|
| NISTu383 | octave | oct | logarithmic_frequency_range | Frequency ratio where f₂/f₁ = 2 |
| NISTu384 | decade | dec | logarithmic_frequency_range | Frequency ratio where f₂/f₁ = 10 |
| NISTu385 | erlang | E | traffic_intensity | Unit of traffic intensity in telecommunications |
| NISTu386 | baud | Bd | symbol_rate | Unit of symbol rate in digital communications |
| NISTu387 | shannon | Sh | information_content | Unit of information entropy (binary) |
| NISTu388 | hartley | Hart | information_content | Unit of information using base-10 logarithm |
